### PR TITLE
fix: SES InvalidS3Configuration by updating aws-cdk version

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -14,15 +14,15 @@
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "20.11.30",
-    "aws-cdk": "^2.136.0",
+    "aws-cdk": "^2.143.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "typescript": "~5.4.3"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-go-alpha": "^2.136.0-alpha.0",
-    "aws-cdk-lib": "^2.136.0",
+    "@aws-cdk/aws-lambda-go-alpha": "^2.143.1-alpha.0",
+    "aws-cdk-lib": "^2.143.1",
     "cdk-nat-asg-provider": "^0.0.5",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
Deploying the app stack fails with an error that SES cannot write into the S3 bucket that is supposed to store the DMARC reports.

```
1:36:13 PM | CREATE_FAILED | AWS::SES::ReceiptRule | FraudmarcCERuleSet<ID>
Could not write to bucket: fraudmarc-ce-app-rua<ID> (Service: AmazonSimpleEmailService; Status Code: 400; Error Code: InvalidS3Configuration; Request ID: <ID>; Proxy: null)
```

There was apparently a bug in the aws-cdk https://github.com/aws/aws-cdk/issues/30143 which is fixed in version 2.143.1. Bumping up the version fixes the issue.